### PR TITLE
fix elapsed timestamp calculation

### DIFF
--- a/UERP.cs
+++ b/UERP.cs
@@ -48,7 +48,7 @@ public static class UERP
 
         // Get start timestamp
         TimeSpan timeSpan = TimeSpan.FromMilliseconds(EditorAnalyticsSessionInfo.elapsedTime);
-        startTimestamp = DateTimeOffset.Now.Add(timeSpan).ToUnixTimeSeconds();
+        startTimestamp = DateTimeOffset.Now.Subtract(timeSpan).ToUnixTimeSeconds();
 
         // Update activity
         EditorApplication.update += Update;
@@ -105,18 +105,12 @@ public static class UERP
 
     private static bool DiscordRunning()
     {
-        Process[] processes = Process.GetProcessesByName("Discord");
+        if (Process.GetProcessesByName("Discord").Length == 0)
+            if (Process.GetProcessesByName("DiscordPTB").Length == 0)
+                if (Process.GetProcessesByName("DiscordCanary").Length == 0)
+                    return false;
 
-        if (processes.Length == 0)
-        {
-            processes = Process.GetProcessesByName("DiscordPTB");
-
-            if (processes.Length == 0)
-            {
-                processes = Process.GetProcessesByName("DiscordCanary");
-            }
-        }
-        return processes.Length != 0;
+        return true;
     }
 
 }


### PR DESCRIPTION
- fixed elapsed time stuck at 00:00
*elapsed* editor time should be **subtracted** from *now* time to get *start* time.
`start = now - elapsed;`

- minor refactor of DiscordRunning()
looks much better now.